### PR TITLE
Rewrite juxt to be allocate less garbage and reuse objects

### DIFF
--- a/src/redux/core.cljc
+++ b/src/redux/core.cljc
@@ -25,26 +25,43 @@
       ([acc x]
        (@rfv acc x)))))
 
-(defn juxt [& rfns]
-  (fn
-    ([] (mapv (fn [f] (f)) rfns))
-    ([acc] (mapv (fn [f a] (f (unreduced a))) rfns acc))
-    ([acc x]
-     (let [all-reduced? (volatile! true)
-           results (mapv (fn [f a]
-                           (if-not (reduced? a)
-                             (do (vreset! all-reduced? false)
-                                 (f a x))
-                             a))
-                         rfns acc)]
-       (if @all-reduced? (reduced results) results)))))
+(defn juxt*
+  "Take a sequence of reducing functions `rfns` and return a reducing function
+  that separately applies each of `rfns` on each incoming element. As the
+  completion, return a vector of fully accumulated values, one per `rfns`.
+
+  This is a stateful \"transducer\". The returned value of this function is not
+  safe for sharing and reuse. Use only once."
+  [rfns]
+  (let [rfns (object-array rfns)
+        n (alength rfns)
+        all-reduced? (object-array 1)]
+    (fn
+      ([] (amap rfns i _ ((aget rfns i))))
+      ([^objects acc]
+       (dotimes [i n]
+         (aset acc i ((aget rfns i) (unreduced (aget acc i)))))
+       (vec acc))
+      ([^objects acc x]
+       (aset all-reduced? 0 true)
+       (dotimes [i n]
+         (let [a (aget acc i)]
+           (when-not (reduced? a)
+             (aset all-reduced? 0 false)
+             (aset acc i ((aget rfns i) a x)))))
+       (if (aget all-reduced? 0) (reduced acc) acc)))))
+
+(defn juxt
+  "Like `juxt*`, but accepts `rfns` as varargs."
+  [& rfns]
+  (juxt* rfns))
 
 (defn facet [rf fns]
   (->> (map (fn [f] (pre-step rf f)) fns)
        (apply juxt)))
 
 (defn fuse [kvs]
-  (post-complete (apply juxt (vals kvs))
+  (post-complete (juxt* (vals kvs))
                  (fn [acc]
                    (zipmap (keys kvs) acc))))
 


### PR DESCRIPTION
This version of juxt uses mutable arrays instead of vectors for intermediate state.

Also introduce `juxt*` that takes a sequence instead of varargs since this is used in this way much more often (Metabase is filled with `apply juxt` calls).